### PR TITLE
fix(auth): Remove confusing success message on admin login

### DIFF
--- a/career-launch/src/pages/admin/admin-login.js
+++ b/career-launch/src/pages/admin/admin-login.js
@@ -52,15 +52,8 @@ export function renderAdmin(rootElement) {
       });
 
       // Parse JSON response
-      const responseData = await response.json();
-
-      // Debugging: Log API responses
-      console.log('Login Response:', responseData); // Display the message from the API response in the label
-
-      errorMessage.textContent =
-        responseData.message || 'Er is een fout opgetreden.';
-      errorMessage.style.display = 'block';
-      errorMessage.style.backgroundColor = 'transparent'; // Remove background styling
+      const responseData = await response.json(); // Debugging: Log API responses
+      console.log('Login Response:', responseData);
 
       if (response.ok) {
         // Store important information in session storage
@@ -94,6 +87,11 @@ export function renderAdmin(rootElement) {
           errorMessage.textContent = 'Je bent geen admin!';
           errorMessage.style.display = 'block';
         }
+      } else {
+        // Show error message only for failed requests
+        errorMessage.textContent =
+          responseData.message || 'Onjuiste inloggegevens.';
+        errorMessage.style.display = 'block';
       }
     } catch (error) {
       // Handle errors


### PR DESCRIPTION
Solves #42 

This pull request refines the error handling logic in the `renderAdmin` function within `career-launch/src/pages/admin/admin-login.js`. The changes aim to improve clarity and user experience by restructuring how error messages are displayed for failed login attempts.

Error handling improvements:

* [`career-launch/src/pages/admin/admin-login.js`](diffhunk://#diff-349ee28fe11a3470368d960cae0446d5b310e1849914c7836957f447a14f43aaR90-R94): Removed redundant error message styling and adjusted the logic to display error messages only for failed requests. The `errorMessage` text now uses `responseData.message` or defaults to 'Onjuiste inloggegevens' for failed login attempts.
* [`career-launch/src/pages/admin/admin-login.js`](diffhunk://#diff-349ee28fe11a3470368d960cae0446d5b310e1849914c7836957f447a14f43aaL55-R56): Consolidated debugging comments and removed unnecessary background styling for error messages, simplifying the code.