### PR TITLE
Add cookie consent banner functionality

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,8 @@ import { renderBedrijfSpeeddatesRequests } from './pages/bedrijf/bedrijf-speedda
 import { renderSearchCriteriaBedrijf } from './pages/bedrijf/search-criteria-bedrijf.js';
 import { renderStudenten } from './pages/bedrijf/studenten.js';
 
+import { showCookieBanner } from './utils/cookie-banner.js';
+
 function renderNotFound(rootElement) {
   rootElement.innerHTML = `
     <div class="not-found-container">
@@ -106,6 +108,9 @@ function setupFooterLinks() {
 // Hook in op elke route change
 window.addEventListener('popstate', setupFooterLinks);
 document.addEventListener('DOMContentLoaded', setupFooterLinks);
+
+// Show cookie banner on every page load unless accepted
+showCookieBanner();
 
 if (
   window.location.protocol === 'http:' &&

--- a/src/main.js
+++ b/src/main.js
@@ -110,7 +110,7 @@ window.addEventListener('popstate', setupFooterLinks);
 document.addEventListener('DOMContentLoaded', setupFooterLinks);
 
 // Show cookie banner on every page load unless accepted
-showCookieBanner();
+document.addEventListener('DOMContentLoaded', showCookieBanner);
 
 if (
   window.location.protocol === 'http:' &&

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,5 +1,4 @@
 import Router from '../router.js';
-import { showCookieBanner } from '../utils/cookie-banner.js';
 import ehbLogo from '/images/EhB-logo-transparant.png';
 
 export function renderHome(rootElement) {
@@ -67,5 +66,3 @@ export function renderHome(rootElement) {
     });
   }
 }
-
-showCookieBanner();

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,4 +1,5 @@
 import Router from '../router.js';
+import { showCookieBanner } from '../utils/cookie-banner.js';
 import ehbLogo from '/images/EhB-logo-transparant.png';
 
 export function renderHome(rootElement) {
@@ -66,3 +67,5 @@ export function renderHome(rootElement) {
     });
   }
 }
+
+showCookieBanner();

--- a/src/utils/cookie-banner.js
+++ b/src/utils/cookie-banner.js
@@ -9,6 +9,7 @@ export function showCookieBanner() {
     cookieBanner.id = 'cookie-banner';
     cookieBanner.setAttribute('role', 'dialog');
     cookieBanner.setAttribute('aria-modal', 'false');
+    cookieBanner.setAttribute('aria-label', 'Cookie toestemming banner');
     cookieBanner.style.cssText = `
       position: fixed;
       bottom: 1.2rem;

--- a/src/utils/cookie-banner.js
+++ b/src/utils/cookie-banner.js
@@ -7,6 +7,8 @@ export function showCookieBanner() {
     if (document.getElementById('cookie-banner')) return;
     const cookieBanner = document.createElement('div');
     cookieBanner.id = 'cookie-banner';
+    cookieBanner.setAttribute('role', 'dialog');
+    cookieBanner.setAttribute('aria-modal', 'false');
     cookieBanner.style.cssText = `
       position: fixed;
       bottom: 1.2rem;

--- a/src/utils/cookie-banner.js
+++ b/src/utils/cookie-banner.js
@@ -1,0 +1,56 @@
+import Router from '../router.js';
+
+export function showCookieBanner() {
+  if (localStorage.getItem('cookieConsent')) return;
+  if (document.getElementById('cookie-banner')) return;
+  requestAnimationFrame(() => {
+    if (document.getElementById('cookie-banner')) return;
+    const cookieBanner = document.createElement('div');
+    cookieBanner.id = 'cookie-banner';
+    cookieBanner.style.cssText = `
+      position: fixed;
+      bottom: 1.2rem;
+      left: 1.2rem;
+      max-width: 300px;
+      min-width: 180px;
+      background: #222;
+      color: #fff;
+      padding: 1rem 1.1rem 1rem 1.1rem;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
+      z-index: 9999;
+      font-size: 0.98rem;
+      box-shadow: 0 4px 18px #0004;
+      border-radius: 12px;
+      gap: 0.6em;
+    `;
+    cookieBanner.innerHTML = `
+      <span style="margin-bottom:0.6em;line-height:1.5;">Deze website gebruikt cookies om de gebruikerservaring te verbeteren. <a href="/privacy" style="color:#4e7bfa;text-decoration:underline;">Meer info</a></span>
+      <button id="cookie-accept-btn" style="align-self:flex-end;background:#4e7bfa;color:#fff;border:none;padding:0.45em 1.1em;border-radius:7px;font-size:0.97em;cursor:pointer;box-shadow:0 2px 8px #0002;">Akkoord</button>
+    `;
+    document.body.appendChild(cookieBanner);
+    const acceptBtn = cookieBanner.querySelector('#cookie-accept-btn');
+    if (acceptBtn) {
+      acceptBtn.addEventListener('click', function () {
+        localStorage.setItem('cookieConsent', 'true');
+        if (cookieBanner && cookieBanner.parentNode) {
+          cookieBanner.parentNode.removeChild(cookieBanner);
+        }
+      });
+    }
+    // Router navigation for privacy link
+    const privacyLink = cookieBanner.querySelector('a[href="/privacy"]');
+    if (privacyLink) {
+      privacyLink.addEventListener('click', function (e) {
+        e.preventDefault();
+        if (typeof Router !== 'undefined' && Router.navigate) {
+          Router.navigate('/privacy');
+        } else {
+          window.location.href = '/privacy';
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
Implement a cookie consent banner that appears on the website, allowing users to accept cookies and storing their consent in local storage. The banner includes a link to the privacy policy and handles navigation accordingly.